### PR TITLE
Add .ico to the list of secure file extensions

### DIFF
--- a/lib/WordPressHTTPS.php
+++ b/lib/WordPressHTTPS.php
@@ -72,7 +72,8 @@ class WordPressHTTPS extends Mvied_Plugin_Modular {
 			'jpg',
 			'jpeg',
 			'png',
-			'gif'
+			'gif',
+			'ico'
 		),
 		'style'  => array(
 			'css'


### PR DESCRIPTION
At https://chaosdorf.de/, we have an apple-touch-icon and "shortcut icon" and noticed that only the touchicon (.png) is changed to HTTPS, not the shortcut icon which ends in .ico, causing an HTTPS mixed content warning.

This patch should fix that.
