### PR TITLE
Fix fatal error in casting objects without __toString() method

### DIFF
--- a/lib/WordPressHTTPS.php
+++ b/lib/WordPressHTTPS.php
@@ -360,6 +360,9 @@ class WordPressHTTPS extends Mvied_Plugin_Modular {
 	 * @return string $string
 	 */
 	public function makeUrlHttps( $string ) {
+      if(is_object($string) && !method_exists($string, "__toString")) {
+         return false;
+
 		if ( (string)$string == '' ) {
 			return false;
 		}


### PR DESCRIPTION
Starting with php 5.2 cast an object to string if the object doesn't have the __toString() method will give a fatal non catchable error. This commit introduce a simple check and fix for that.