### PR TITLE
Update Core.php to fix an error with a deprecated function 'force_ssl_login'

### DIFF
--- a/lib/WordPressHTTPS/Module/Core.php
+++ b/lib/WordPressHTTPS/Module/Core.php
@@ -296,7 +296,7 @@ class WordPressHTTPS_Module_Core extends Mvied_Plugin_Module {
 	 */
 	public function secure_login( $force_ssl, $post_id = 0, $url = '' ) {
 		if ( $url != '' && $this->getPlugin()->isUrlLocal($url) ) {
-			if ( force_ssl_login() && preg_match('/wp-login\.php$/', $url) === 1 ) {
+			if ( force_ssl_admin() && preg_match('/wp-login\.php$/', $url) === 1 ) {
 				$force_ssl = true;
 			}
 		}


### PR DESCRIPTION
Changed 'force_ssl_login' to 'force_ssl_admin' to fix an error caused since WordPress 4.4 came out. Reference: https://wordpress.org/support/topic/breaks-site-after-wp-44-update?replies=4