### PR TITLE
Added compatibility with Wordpress 4.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /nbproject/
 phpunit.xml
 /tests/
+.idea

--- a/lib/WordPressHTTPS.php
+++ b/lib/WordPressHTTPS.php
@@ -367,8 +367,9 @@ class WordPressHTTPS extends Mvied_Plugin_Modular {
 	 * @return string $string
 	 */
 	public function makeUrlHttps( $string ) {
-      if(is_object($string) && !method_exists($string, "__toString")) {
-         return false;
+		if(is_object($string) && !method_exists($string, "__toString")) {
+			return false;
+		}
 
 		if ( (string)$string == '' ) {
 			return false;

--- a/lib/WordPressHTTPS/Module/Core.php
+++ b/lib/WordPressHTTPS/Module/Core.php
@@ -295,9 +295,21 @@ class WordPressHTTPS_Module_Core extends Mvied_Plugin_Module {
 	 * @return boolean $force_ssl
 	 */
 	public function secure_login( $force_ssl, $post_id = 0, $url = '' ) {
-		if ( $url != '' && $this->getPlugin()->isUrlLocal($url) ) {
-			if ( force_ssl_login() && preg_match('/wp-login\.php$/', $url) === 1 ) {
-				$force_ssl = true;
+		/**
+		 * Forward compatibility for Wordpress 4.4+
+		 */
+
+		if ( version_compare(get_bloginfo('version'), '4.4', '>') ) {
+			if ( $url != '' && $this->getPlugin()->isUrlLocal($url) ) {
+				if ( force_ssl_admin() && preg_match('/wp-login\.php$/', $url) === 1 ) {
+					$force_ssl = true;
+				}
+			}
+		} else {
+			if ( $url != '' && $this->getPlugin()->isUrlLocal($url) ) {
+				if ( force_ssl_login() && preg_match('/wp-login\.php$/', $url) === 1 ) {
+					$force_ssl = true;
+				}
 			}
 		}
 		return $force_ssl;


### PR DESCRIPTION
# Implements 

* Added `.idea` directory to `.gitignore` file for Jetbrains' products
* Fixed missed curly brackets 
* Added version compare to manage deprecation message from Wordpress core.

> Roughly tested on Wordpress 4.4.1